### PR TITLE
Disable pager

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const { master, slave } = openpty();
 xterm.loadAddon(master);
 
 const main = async () => {
-  const args = ["--disable-gems", "-e", "GC.disable; require 'irb'; IRB.start(__FILE__)"];
+  const args = ["--disable-gems", "-e", "GC.disable; require 'irb'; IRB.setup(nil, argv: ['--no-pager']); IRB::Irb.new.run"];
   console.log(`$ ruby.wasm ${args.join(" ")}`);
   const defaultModule = {
     locateFile: (path) => "./ruby-wasm-emscripten-dist/" + path,


### PR DESCRIPTION
https://mame.github.io/emirb/ crashes with `ls`.

```
irb(main):001> ls
/usr/local/lib/ruby/3.3.0+0/irb/pager.rb:71:in `popen': popen() is not available (NotImplementedError)
        from /usr/local/lib/ruby/3.3.0+0/irb/pager.rb:71:in `block in setup_page
        from /usr/local/lib/ruby/3.3.0+0/irb/pager.rb:61:in `each'
        from /usr/local/lib/ruby/3.3.0+0/irb/pager.rb:61:in `setup_pager'
        from /usr/local/lib/ruby/3.3.0+0/irb/pager.rb:21:in `page'
        from /usr/local/lib/ruby/3.3.0+0/irb/pager.rb:12:in `page_content'
        from /usr/local/lib/ruby/3.3.0+0/irb/cmd/ls.rb:86:in `print_result'
        from /usr/local/lib/ruby/3.3.0+0/irb/cmd/ls.rb:38:in `execute'
        from /usr/local/lib/ruby/3.3.0+0/irb/cmd/nop.rb:35:in `execute'
        from /usr/local/lib/ruby/3.3.0+0/irb/extend-command.rb:265:in `irb_ls'
        from (irb):1:in `<main>'
        from /usr/local/lib/ruby/3.3.0+0/irb/workspace.rb:117:in `eval'
        from /usr/local/lib/ruby/3.3.0+0/irb/workspace.rb:117:in `evaluate'
        from /usr/local/lib/ruby/3.3.0+0/irb/context.rb:570:in `evaluate'
        from /usr/local/lib/ruby/3.3.0+0/irb.rb:516:in `block (2 levels) in eval_input'
        from /usr/local/lib/ruby/3.3.0+0/irb.rb:828:in `signal_status'
        from /usr/local/lib/ruby/3.3.0+0/irb.rb:509:in `block in eval_input'
        from /usr/local/lib/ruby/3.3.0+0/irb.rb:591:in `block in each_top_level_statement'
        from <internal:kernel>:187:in `loop'
        from /usr/local/lib/ruby/3.3.0+0/irb.rb:586:in `each_top_level_statement'
        from /usr/local/lib/ruby/3.3.0+0/irb.rb:508:in `eval_input'
        from /usr/local/lib/ruby/3.3.0+0/irb.rb:495:in `block in run'
        from /usr/local/lib/ruby/3.3.0+0/irb.rb:494:in `catch'
        from /usr/local/lib/ruby/3.3.0+0/irb.rb:494:in `run'
        from /usr/local/lib/ruby/3.3.0+0/irb.rb:396:in `start'
        from -e:1:in `<main>'
Maybe IRB bug!
```

It seems that there are a lot of ls outputs and unsupported errors when trying to start pager.


When disable pager, ls works well.

```
irb(main):002> IRB.conf[:USE_PAGER] = false
=> false
irb(main):003> ls
Object.methods: 
  backtrace                  bindings                   
  bt                         cb                         
  chws                       conf                       
  context                    continue                   
...
```

Therefore, I tried to make the code to start with PAGER disabled.
In the local ruby, the code like this certainly started up with the pager disabled.

```
$ ruby -rirb -e "IRB.setup(nil, argv: ['--no-pager']); IRB::Irb.new.run"
irb(main):001> IRB.conf[:USE_PAGER]
=> false
```